### PR TITLE
New behavior for moving nodes between projects

### DIFF
--- a/common/hil_slurm_client.py
+++ b/common/hil_slurm_client.py
@@ -34,7 +34,7 @@ def hil_move_node(node, dest_project, source_project=None):
     if source_project is None:
         source_project = node_info['project']
     else:
-        assert source_project is node_info['project'], "Project mismatch"
+        assert source_project == node_info['project'], "Project mismatch"
 
     hil_client.node.power_off(node)
     _remove_all_networks(node, hil_client)
@@ -70,7 +70,7 @@ def hil_free_nodes(nodelist):
     '''
     for node in nodelist:
         hil_move_node(node, HIL_SLURM_PROJECT)
-        # should probably atach the networks back for SLURM project
+        # should probably attach the networks back for SLURM project
         # 1. either copy the network config off of some other node in SLURM
         # 2. reconnect every network in the SLURM PROJECT
         # 3. hardcode some network names in a config file that needs to be

--- a/common/hil_slurm_client.py
+++ b/common/hil_slurm_client.py
@@ -14,7 +14,6 @@ from hil_slurm_logging import log_info, log_debug, log_error
 from hil_slurm_settings import HIL_ENDPOINT, HIL_USER, HIL_PW, HIL_SLURM_PROJECT
 
 
-
 def hil_client_connect(endpoint_ip, name, pw):
     '''
     '''
@@ -28,6 +27,21 @@ def check_hil_interface():
     hil_client = hil_init()
 
 
+def hil_move_node(node, dest_project, source_project=None):
+    hil_client = hil_init()
+    node_info = hil_client.node.show(node)
+
+    if source_project is None:
+        source_project = node_info['project']
+    else:
+        assert source_project is node_info['project'], "Project mismatch"
+
+    hil_client.node.power_off(node)
+    _remove_all_networks(node, hil_client)
+    hil_client.project.detach(source_project, node)
+    hil_client.project.connect(dest_project, node)
+
+
 def hil_reserve_nodes(nodelist, dest_project):
     '''
     Cause HIL nodes to move from the Slurm loaner project to a new HIL project.
@@ -39,21 +53,11 @@ def hil_reserve_nodes(nodelist, dest_project):
     network is also controlled by HIL. If we removed all networks, then we will
     not be able to perform any ipmi operations on nodes.
     '''
-    hil_client = hil_init()
     for node in nodelist:
-        # get information from node
-        node_info = hil_client.node.show(node)
-        project = node_info['project']
-        # check that the correct project is stored
-        assert project == HIL_SLURM_PROJECT
-        # prep and move the node to free pool
-        hil_client.node.power_off(node)
-        _remove_all_networks(node, hil_client)
-        hil_client.project.detach(project, node)
-        hil_client.project.connect(dest_project, node)
+        hil_move_node(node, dest_project, source_project=HIL_SLURM_PROJECT)
 
 
-def hil_free_nodes(nodelist, dest_project):
+def hil_free_nodes(nodelist):
     '''
     Cause HIL nodes to move from a HIL project to the Slurm loaner project.
 
@@ -64,17 +68,13 @@ def hil_free_nodes(nodelist, dest_project):
     network is also controlled by HIL. If we removed all networks, then we will
     not be able to perform any ipmi operations on nodes.
     '''
-    hil_client = hil_init()
     for node in nodelist:
-        # get information from node
-        node_info = hil_client.node.show(node)
-        project = node_info['project']
-        # check that the node is not in Slurm already
-        assert project != HIL_SLURM_PROJECT
-        # prep and return node to Slurm
-        hil_client.node.power_off(node)
-        _remove_all_networks(node, hil_client)
-        hil_client.project.connect(HIL_SLURM_PROJECT, node)
+        hil_move_node(node, HIL_SLURM_PROJECT)
+        # should probably atach the networks back for SLURM project
+        # 1. either copy the network config off of some other node in SLURM
+        # 2. reconnect every network in the SLURM PROJECT
+        # 3. hardcode some network names in a config file that needs to be
+        # reattached.
 
 
 def hil_init():

--- a/common/hil_slurm_client.py
+++ b/common/hil_slurm_client.py
@@ -11,10 +11,7 @@ import urllib
 from hil.client.client import Client, RequestsHTTPClient
 from hil.client.base import FailedAPICallException
 from hil_slurm_logging import log_info, log_debug, log_error
-from hil_slurm_settings import HIL_ENDPOINT, HIL_USER, HIL_PW
-
-# Place holder -> need to assert that the node's Slurm proj matches this
-slurm_project = "slurm"
+from hil_slurm_settings import HIL_ENDPOINT, HIL_USER, HIL_PW, HIL_SLURM_PROJECT
 
 
 
@@ -31,9 +28,9 @@ def check_hil_interface():
     hil_client = hil_init()
 
 
-def hil_reserve_nodes(nodelist):
+def hil_reserve_nodes(nodelist, dest_project):
     '''
-    Cause HIL nodes to move from the Slurm loaner project to the HIL free pool.
+    Cause HIL nodes to move from the Slurm loaner project to a new HIL project.
 
     This methods first powers off the nodes, then disconnects all networks and
     then moves the node from the Slurm project to the free pool.
@@ -48,16 +45,17 @@ def hil_reserve_nodes(nodelist):
         node_info = hil_client.node.show(node)
         project = node_info['project']
         # check that the correct project is stored
-        assert project == slurm_project
+        assert project == HIL_SLURM_PROJECT
         # prep and move the node to free pool
         hil_client.node.power_off(node)
         _remove_all_networks(node, hil_client)
         hil_client.project.detach(project, node)
+        hil_client.project.connect(dest_project, node)
 
 
-def hil_free_nodes(nodelist):
+def hil_free_nodes(nodelist, dest_project):
     '''
-    Cause HIL nodes to move from the HIL free pool to the Slurm loaner project.
+    Cause HIL nodes to move from a HIL project to the Slurm loaner project.
 
     This methods first powers off the nodes, then disconnects all networks and
     then moves the node from the free pool to the Slurm project.
@@ -72,11 +70,11 @@ def hil_free_nodes(nodelist):
         node_info = hil_client.node.show(node)
         project = node_info['project']
         # check that the node is not in Slurm already
-        assert project != slurm_project
+        assert project != HIL_SLURM_PROJECT
         # prep and return node to Slurm
         hil_client.node.power_off(node)
         _remove_all_networks(node, hil_client)
-        hil_client.project.connect(slurm_project, node)
+        hil_client.project.connect(HIL_SLURM_PROJECT, node)
 
 
 def hil_init():

--- a/common/hil_slurm_settings.py
+++ b/common/hil_slurm_settings.py
@@ -28,6 +28,8 @@ HIL_PARTITION_PREFIX = 'debug'
 HIL_RESERVATION_DEFAULT_DURATION = 24 * 60 * 60		# Seconds
 HIL_RESERVATION_GRACE_PERIOD = 4 * 60 * 60		# Seconds
 
+HIL_SLURM_PROJECT = 'slurm'
+
 # Partition validation controls
 
 RES_CHECK_DEFAULT_PARTITION = False


### PR DESCRIPTION
- Moved Slurm project to config file.
- Nodes now move to/from a given project, not free pool.