### PR TITLE
Refactor the HIL client

### DIFF
--- a/common/hil_slurm_client.py
+++ b/common/hil_slurm_client.py
@@ -14,6 +14,14 @@ from hil_slurm_logging import log_info, log_debug, log_error
 from hil_slurm_settings import HIL_ENDPOINT, HIL_USER, HIL_PW
 
 
+class HILClientFailure(Exception):
+    """Exception indicating that the HIL client failed"""
+
+
+class ProjectMismatchError(Exception):
+    """Raised when projects don't match"""
+
+
 def hil_client_connect(endpoint_ip, name, pw):
     '''
     Connect to the HIL server and return a HIL Client instance
@@ -37,53 +45,45 @@ def hil_reserve_nodes(nodelist, from_project, hil_client=None):
     Cause HIL nodes to move from the 'from' project to the HIL free pool.
     Typically, the 'from' project is the Slurm loaner project.
 
-    This methods first powers off the nodes, then disconnects all networks, 
+    This methods first powers off the nodes, then disconnects all networks,
     then moves the node from the 'from' project to the free pool.
 
     We power off the nodes before removing the networks because the IPMI
     network is also controlled by HIL. If we removed all networks, then we will
     not be able to perform any IPMI operations on nodes.
     '''
-    status = True
-
+    # this might cause a loop? since hil_init calls hil_client_connect
+    # which can return None. We can either have a counter to give it a
+    # reasonable number of tries before raising an exception.
     if not hil_client:
         hil_client = hil_init()
 
+    # Get information from node and ensure that the node is actually connected
+    # to <from_project> before proceeding.
     for node in nodelist:
-        # get information from node
-        try:
-            node_info = hil_client.node.show(node)
-        except:
-            log_error('HIL reservation failure: HIL node info unavailable, node `%s`' % node)
-            status = False
-            continue
+        node_info = show_node(hil_client, node)
 
         project = node_info['project']
         if (project != from_project):
             log_error('HIL reservation failure: Node `%s` (in project `%s`) not in `%s` project' % (node, project, from_project))
-            status = False
-            continue
+            raise ProjectMismatchError()
 
-        # prep and move the node from the Slurm project to the HIL free pool
-        try:
-            hil_client.node.power_off(node)
-        except:
-            log_error('HIL reservation failure: Unable to power off node `%s`' % node)
-            status = False
-            continue
+    # Power off all nodes.
+    for node in nodelist:
+        power_off_node(hil_client, node)
 
-        if not _remove_all_networks(node, hil_client):
-            status = False
-            continue
+    # Remove all networks from nodes.
+    for node in nodelist:
+        _remove_all_networks(hil_client, node)
 
+    # Finally, remove node from project.
+    for node in nodelist:
         try:
             hil_client.project.detach(from_project, node)
+            log_info('Node `%s` removed from project `%s`' % (node, from_project))
         except:
             log_error('HIL reservation failure: Unable to detach node `%s` from project `%s`' % (node, from_project))
-            status = False
-            continue
-
-    return status
+            raise HILClientFailure()
 
 
 def hil_free_nodes(nodelist, to_project, hil_client=None):
@@ -91,54 +91,45 @@ def hil_free_nodes(nodelist, to_project, hil_client=None):
     Cause HIL nodes to move the HIL free pool to the 'to' project.
     Typically, the 'to' project is the Slurm loaner project.
 
-    This method first powers off the nodes, then disconnects all networks, 
+    This method first powers off the nodes, then disconnects all networks,
     then moves the node from the free pool to the 'to' project.
 
     We power off the nodes before removing the networks because the IPMI
     network is also controlled by HIL. If we removed all networks, then we will
     not be able to perform any IPMI operations on nodes.
     '''
-    status = True
 
     if not hil_client:
         hil_client = hil_init()
 
+    # Get information from node and ensure that the node is actually connected
+    # to <from_project> before proceeding.
     for node in nodelist:
-        # get information from node
-        try:
-            node_info = hil_client.node.show(node)
-        except:
-            log_error('HIL release failure: HIL node info unavailable, node `%s`' % node)
-            status = False
-            continue
+        node_info = show_node(hil_client, node)
 
         # If the node is in the Slurm project now, skip further processing, but don't indicate
         # failure.
         project = node_info['project']
         if (project == to_project):
             log_info('HIL release: Node `%s` already in `%s` project, skipping' % (node, to_project))
-            continue
+            nodelist.remove(node)
 
-        # prep and move the node from the HIL free pool to the Slurm project
-        try:
-            hil_client.node.power_off(node)
-        except:
-            log_error('HIL release failure: Unable to power off node `%s`' % node)
-            status = False
-            continue
-            
-        if not _remove_all_networks(node, hil_client):
-            status = False
-            continue
+    # Power off all nodes.
+    for node in nodelist:
+        power_off_node(hil_client, node)
 
+    # Remove all networks from nodes.
+    for node in nodelist:
+        _remove_all_networks(hil_client, node)
+
+    # Finally, connect node to <to_project>
+    for node in nodelist:
         try:
             hil_client.project.connect(to_project, node)
+            log_info('Node `%s` connected to project `%s`' % (node, to_project))
         except:
             log_error('HIL reservation failure: Unable to connect node `%s` to project `%s`' % (node, to_project))
-            status = False
-            continue
-
-    return status
+            raise HILClientFailure()
 
 
 def hil_init():
@@ -149,13 +140,7 @@ def _remove_all_networks(node, hil_client):
     '''
     Disconnect all networks from all of the node's NICs
     '''
-    try:
-        node_info = hil_client.node.show(node)
-    except:
-        log_error('Failed to retrieve info for HIL node `%s`' % node)
-        return False
-
-    status = True
+    node_info = show_node(hil_client, node)
 
     # get node information and then iterate on the nics
     for nic in node_info['nics']:
@@ -165,11 +150,30 @@ def _remove_all_networks(node, hil_client):
         if port and switch:
             try:
                 hil_client.port.port_revert(switch, port)
+                log_info('Removed all networks from node `%s`' % node)
             except:
                 log_error('Failed to revert port `%s` on node `%s` switch `%s`' % (port, node, switch))
-                status = False
-                continue
+                raise HILClientFailure()
 
-    return status
 
-# EOF
+def show_node(hil_client, node):
+    """Returns node information and takes care of handling exceptions"""
+    try:
+        node_info = hil_client.node.show(node)
+        return node_info
+    except Exception as ex:
+        # log a note for the admins, and the exact exception before raising
+        # an error.
+        log_error('HIL reservation failure: HIL node info unavailable, node `%s`' % node)
+        log_error(ex)
+        raise HILClientFailure()
+
+
+def power_off_node(hil_client, node):
+    try:
+        hil_client.node.power_off(node)
+        log_info('Node `%s` succesfully powered off' % node)
+    except Exception as ex:
+        log_error('HIL reservation failure: Unable to power off node `%s`' % node)
+        log_error(ex)
+        raise HILClientFailure()

--- a/common/hil_slurm_client.py
+++ b/common/hil_slurm_client.py
@@ -81,7 +81,7 @@ def hil_reserve_nodes(nodelist, from_project, hil_client=None):
         try:
             hil_client.project.detach(from_project, node)
             log_info('Node `%s` removed from project `%s`' % (node, from_project))
-        except:
+        except FailedAPICallException, ConnectionError:
             log_error('HIL reservation failure: Unable to detach node `%s` from project `%s`' % (node, from_project))
             raise HILClientFailure()
 
@@ -127,7 +127,7 @@ def hil_free_nodes(nodelist, to_project, hil_client=None):
         try:
             hil_client.project.connect(to_project, node)
             log_info('Node `%s` connected to project `%s`' % (node, to_project))
-        except:
+        except FailedAPICallException, ConnectionError:
             log_error('HIL reservation failure: Unable to connect node `%s` to project `%s`' % (node, to_project))
             raise HILClientFailure()
 
@@ -136,7 +136,7 @@ def hil_init():
     return hil_client_connect(HIL_ENDPOINT, HIL_USER, HIL_PW)
 
 
-def _remove_all_networks(node, hil_client):
+def _remove_all_networks(hil_client, node):
     '''
     Disconnect all networks from all of the node's NICs
     '''
@@ -151,7 +151,7 @@ def _remove_all_networks(node, hil_client):
             try:
                 hil_client.port.port_revert(switch, port)
                 log_info('Removed all networks from node `%s`' % node)
-            except:
+            except FailedAPICallException, ConnectionError:
                 log_error('Failed to revert port `%s` on node `%s` switch `%s`' % (port, node, switch))
                 raise HILClientFailure()
 
@@ -161,11 +161,10 @@ def show_node(hil_client, node):
     try:
         node_info = hil_client.node.show(node)
         return node_info
-    except Exception as ex:
+    except FailedAPICallException, ConnectionError:
         # log a note for the admins, and the exact exception before raising
         # an error.
         log_error('HIL reservation failure: HIL node info unavailable, node `%s`' % node)
-        log_error(ex)
         raise HILClientFailure()
 
 
@@ -173,7 +172,6 @@ def power_off_node(hil_client, node):
     try:
         hil_client.node.power_off(node)
         log_info('Node `%s` succesfully powered off' % node)
-    except Exception as ex:
+    except FailedAPICallException, ConnectionError:
         log_error('HIL reservation failure: Unable to power off node `%s`' % node)
-        log_error(ex)
         raise HILClientFailure()

--- a/common/hil_slurm_client.py
+++ b/common/hil_slurm_client.py
@@ -129,14 +129,6 @@ def hil_free_nodes(nodelist, to_project, hil_client=None):
             log_info('HIL release: Node `%s` already in `%s` project, skipping' % (node, to_project))
             nodelist.remove(node)
 
-    # Power off all nodes.
-    for node in nodelist:
-        power_off_node(hil_client, node)
-
-    # Remove all networks from nodes.
-    for node in nodelist:
-        _remove_all_networks(hil_client, node)
-
     # Finally, connect node to <to_project>
     for node in nodelist:
         try:

--- a/common/hil_slurm_logging.py
+++ b/common/hil_slurm_logging.py
@@ -37,26 +37,26 @@ def _log_common(logger_fn, message=None, separator_s=None, print_exception=False
 
 
 def log_error(message=None):
-    _log_common(logging.error, message, separator_s=warn_error_sep, exception=True)
+    _log_common(logging.error, message, separator_s=warn_error_sep, print_exception=True)
 
 
 def log_warning(message=None):
-    _log_common(logging.warning, message, separator_s=warn_error_sep, exception=True)
+    _log_common(logging.warning, message, separator_s=warn_error_sep, print_exception=True)
 
 
-def log_info(message, separator=False):
-    if separator:
+def log_info(message, separator_s=False):
+    if separator_s:
         s = info_debug_sep
     else:
         s = None
-    _log_common(logging.info, message, separator_s=s, exception=False)
+    _log_common(logging.info, message, separator_s=s, print_exception=False)
 
 
-def log_debug(message, separator=False):
-    if separator:
+def log_debug(message, separator_s=False):
+    if separator_s:
         s = info_debug_sep
     else:
         s = None
-    _log_common(logging.debug, message, separator_s=s, exception=False)
+    _log_common(logging.debug, message, separator_s=s, print_exception=False)
 
 # EOF

--- a/common/hil_slurm_settings.py
+++ b/common/hil_slurm_settings.py
@@ -13,7 +13,7 @@ SLURM_INSTALL_DIR = '/usr/bin/'
 HIL_SLURMCTLD_PROLOG_LOGFILE = '/var/log/moc_hil_ulsr/hil_prolog.log'
 HIL_MONITOR_LOGFILE = '/var/log/moc_hil_ulsr/hil_monitor.log'
 
-HIL_ENDPOINT = "http://128.31.28.156:80"
+HIL_ENDPOINT = "http://10.0.0.16:80"
 HIL_USER = 'admin'
 HIL_PW = 'NavedIsSleepy'
 HIL_SLURM_PROJECT = 'slurm'

--- a/test/hil_client_test.py
+++ b/test/hil_client_test.py
@@ -1,0 +1,72 @@
+"""
+General info about these tests
+
+The tests assusme that the nodes are in the <from_project> which is set to be the
+"slurm" project, since that is what we are testing here.
+
+If all tests pass successfully, then nodes are back in their original state.
+
+Class TestHILReserve moves nodes out of the slurm project and into the free pool;
+and TestHILRelease puts nodes back into the slurm project from the free pool
+
+run the tests like this
+py.test <path to testfile>
+py.test hil_client_test
+"""
+
+import inspect
+import sys
+import pytest
+import requests
+from os.path import realpath, dirname, isfile, join
+import uuid
+
+libdir = realpath(join(dirname(inspect.getfile(inspect.currentframe())), '../common'))
+sys.path.append(libdir)
+
+import hil_slurm_client
+
+
+# Some constants useful for tests
+nodelist = ['slurm-compute1', 'slurm-compute2', 'slurm-compute3']
+hil_client = hil_slurm_client.hil_init()
+to_project = 'slurm'
+from_project = 'slurm'
+
+bad_hil_client = hil_slurm_client.hil_client_connect('http://127.3.2.1',
+                                                     'baduser', 'badpassword')
+
+
+class TestHILReserve:
+    """Tests various hil_reserve cases"""
+
+    def test_hil_reserve_success(self):
+        """test the regular success scenario"""
+
+        # should raise an error if <from_project> doesn't add up.
+        with pytest.raises(hil_slurm_client.ProjectMismatchError):
+            random_project = str(uuid.uuid4())
+            hil_slurm_client.hil_reserve_nodes(nodelist, random_project, hil_client)
+
+        # should run without any errors
+        hil_slurm_client.hil_reserve_nodes(nodelist, from_project, hil_client)
+
+        # should raise error if a bad hil_client is passed
+        with pytest.raises(requests.ConnectionError):
+            hil_slurm_client.hil_reserve_nodes(nodelist, from_project, bad_hil_client)
+
+
+class TestHILRelease:
+    """Test various hil_release cases"""
+    def test_hil_release(self):
+        # should raise error if a bad hil_client is passed
+        with pytest.raises(requests.ConnectionError):
+            hil_slurm_client.hil_free_nodes(nodelist, to_project, bad_hil_client)
+
+        # calling it with a functioning hil_client should work
+        hil_slurm_client.hil_free_nodes(nodelist, to_project, hil_client)
+
+        # At this point, nodes are already owned by the <to_project>
+        # calling it again should have no affect.
+        hil_slurm_client.hil_free_nodes(nodelist, to_project, hil_client)
+


### PR DESCRIPTION
I did this in a slightly more pythonic way (raising errors and such).

* Instead of returning a boolean `status`, the methods now raise an error.  
* The callers can then use the try-except blocks to catch these errors and handle it. So I'll update the callers too if we are okay going forward with this approach.
* Raising errors also break the flow of the code which stops any further processing. 

I haven't tested this with the whole package. Can I install it in a virtualenv on the slurm-controller VM and test it @tpd001?