### PR TITLE
Reorg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,99 @@
+PROJECT = ulsr
+
+HIL_CMDS = hil_reserve hil_release
+LOCAL_BIN = /usr/local/bin
+
+PROLOG_FILES = hil_slurmctld_prolog.py hil_slurmctld_prolog.sh hil_slurmctld_epilog.sh
+
+MONITOR_FILES = hil_slurm_monitor.py hil_slurm_monitor.sh
+
+NET_AUDIT_FILES =
+
+LIB_FILES = hil_slurm_client.py hil_slurm_constants.py hil_slurm_helpers.py hil_slurm_logging.py hil_slurm_settings.py
+
+DOCS = README.md LICENSE 
+
+SLURM_USER = slurm
+SLURM_USER = tdonahue
+SLURM_USER_DIR=/home/$(SLURM_USER)
+
+INSTALL_USER = centos
+INSTALL_USER_DIR=/home/$(INSTALL_USER)
+
+SLURM_CONF_FILE_PATH = /etc/slurm
+SLURM_CONF_FILE_NAME = slurm.conf
+SLURM_CONF_FILE = $(SLURM_CONF_FILE_PATH)/$(SLURM_CONF_FILE_NAME)
+
+PYTHON = python2.7
+PYTHON_PKGS = python-hostlist requests git+https://github.com/cci-moc/hil.git@v0.2
+
+VENV_SITE_PKG_DIR = $(SLURM_USER_DIR)/scripts/ve/lib/$(PYTHON)/site-packages
+
+NFS_SHARED_DIR = /shared
+ULSR_SHARED_DIR = $(NFS_SHARED_DIR)/ulsr
+ULSR_LOGFILE_DIR = /var/log/ulsr
+
+INSTALL = /usr/bin/install -m 755 -g $(SLURM_USER) -o $(SLURM_USER)
+
+
+.PHONY: all install clean python_packages nfs_share
+
+all: install
+
+install: yum_packages nfs_share
+
+	# ULSR log file directory
+	mkdir -p $(ULSR_LOGFILE_DIR)
+	chmod 755 $(ULSR_LOGFILE_DIR)
+	chown $(SLURM_USER):$(SLURM_USER) $(ULSR_LOGFILE_DIR)
+
+	# Virtual environment and support libraries
+	mkdir -p $(SLURM_USER_DIR)/scripts
+	virtualenv -p $(PYTHON) $(SLURM_USER_DIR)/scripts/ve
+	source $(SLURM_USER_DIR)/scripts/ve/bin/activate
+	pip install $(PYTHON_PKGS)
+	deactivate
+
+	# Copy common library modules
+	$(INSTALL) $(LIB_FILES) $(VENV_SITE_PKG_DIR)
+
+	# Copy HIL commands to local bin directory and NFS-shared bin directory
+	$(INSTALL) $(HIL_CMDS) $(LOCAL_BIN)
+	$(COPY) $(HIL_CMDS) $(ULSR_SHARED_DIR)/bin
+
+	# Copy prolog and epilog scripts
+	$(INSTALL) $(PROLOG_FILES) $(SLURM_USER_DIR)/scripts
+
+	# Copy network audit scripts
+	$(INSTALL) $(NET_AUDIT_FILES) $(SLURM_USER_DIR)/scripts
+
+
+python_packages:
+	yum makecache -y fast
+	yum install -y emacs
+	yum install -y nfs-utils
+	yum install -y virtualenv
+
+nfs_share:
+	mkdir -p $(NFS_SHARED_DIR)
+	chmod 777 $(NFS_SHARED_DIR)
+	chown nobody:nobody $(NFS_SHARED_DIR)
+	chkconfig nfs on
+	service rpcbind start
+	service nfs start
+	echo '$(NFS_SHARED_DIR) *(rw,sync,no_root_squash)' >> /etc/exports
+	exportfs -a
+
+	mkdir -p $(ULSR_SHARED_DIR)/bin
+	chmod -R 700 $(ULSR_SHARED_DIR)/bin
+	chown -R $(INSTALL_USER):$(INSTALL_USER) $(ULSR_SHARED_DIR)/bin
+
+clean:
+	rm -rf $(SLURM_USER_DIR)/scripts
+	rm -rf $(ULSR_LOGFILE_DIR)
+	cd $(LOCAL_BIN)
+	rm -f $(HIL_CMDS)
+	cd $(VENV_SITE_PKG_DIR)
+	rm -rf $(LIB_FILES)
+	rm -rf $(SLURM_USER_DIR)/scripts/ve
+# EOF

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ LIB_FILES = hil_slurm_client.py hil_slurm_constants.py hil_slurm_helpers.py hil_
 DOCS = README.md LICENSE 
 
 SLURM_USER = slurm
-SLURM_USER = tdonahue
+# SLURM_USER = tdonahue
 SLURM_USER_DIR=/home/$(SLURM_USER)
 
 INSTALL_USER = centos
@@ -67,6 +67,13 @@ install: yum_packages nfs_share
 	# Copy network audit scripts
 	$(INSTALL) $(NET_AUDIT_FILES) $(SLURM_USER_DIR)/scripts
 
+	# Update Slurm configuration file and share with compute nodes
+	echo '# Slurmctld Prolog and Epilog' >> $(SLURM_CONF_FILE)
+	echo 'PrologSlurmctld=$(SLURM_USER_DIR)/scripts/hil_slurmctld_prolog.sh' >> $(SLURM_CONF_FILE)
+	echo 'EpilogSlurmctld=$(SLURM_USER_DIR)/scripts/hil_slurmctld_epilog.sh' >> $(SLURM_CONF_FILE)
+
+	echo 'Provision Slurm compute nodes, then restart Slurm control daemon.'
+	echo 'Installation complete.'
 
 python_packages:
 	yum makecache -y fast

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MOC HIL User Level Slurm Reservations (ULSR)
 
-V1.1  30-Oct-2017
+V2.0  2-Nov-2017
 
 # Introduction
 
@@ -31,19 +31,17 @@ Linux but has not been tested in that distribution environment.
 
 To reserve a HIL node, specify the ```hil_reserve``` command as a job
 to the Slurm ```srun(1)``` or ```sbatch(1)``` command:
-
 ```
 $ srun hil_reserve
 ```
-
 To verify the reservation was created, run the ```scontrol show
 reservation``` command:
-
 ``` 
 $ scontrol show reservation
 ```
-If successful, two reservations similiar to the following should appear:
-
+If successful, immediately after execution of the ```srun
+hil_reserve``` command, a Slurm reservation similiar to the following
+should appear:
 ```
 ReservationName=flexalloc_MOC_reserve_centos_1000_2017-06-26T17:20:32
 StartTime=2017-06-26T17:20:32 EndTime=2017-06-26T21:25:32
@@ -52,6 +50,8 @@ PartitionName=(null) Flags=MAINT,IGNORE_JOBS,S PEC_NODES,ALL_NODES
 TRES=cpu=1 Users=centos Accounts=(null) Licenses=(null) State=ACTIVE
 BurstBuffer=(null) Watts=n/a 
 ```
+Some time later, after the periodic execution of the ULSR monitor, a
+paired release reservation similiar to the following should appear:
 
 ```
 ReservationName=flexalloc_MOC_release_centos_1000_2017-06-26T17:20:32
@@ -73,8 +73,7 @@ run the job:
 ```
 $ srun --reservation=flexalloc_MOC_reserve_centos_1000_2017-06-26T17:20:32 hil_release
 ```
-This will ultimately cause removal of both the reserve and release
-reservations.  
+This will ultimately remove both the reserve and release reservations.
 
 ## Resource Sharing
 
@@ -151,9 +150,9 @@ end user project:
     as the 'Slurm project' or the 'Slurm loaner project'.
 
 Once a Slurm server node has been placed in a Slurm HIL reservation
-with ```hil_reserve```, it may be necessary for the HIL end user to
-run HIL management commands to cause the server node to fully
-participate in a HIL user project.  This requirement may be
+through the use of ```hil_reserve```, it may be necessary for the HIL
+end user to run HIL management commands to cause the server node to
+fully participate in a HIL user project.  This requirement may be
 interpreted as consistent with a 'two-screen' management model.
 
 
@@ -162,17 +161,17 @@ interpreted as consistent with a 'two-screen' management model.
 Beyond any requirements imposed by the HIL software and Slurm, the
 following apply to the user level Slurm reservation software.
 
-  1. All nodes in the HIL reservation pool are configured in a singleo
+  1. All nodes in the HIL reservation pool are configured in a single
   Slurm partition.  
 
-  2. The Slurm controller node in the partition is not available for
-  HIL operations and is **not** marked with the ```HIL``` feature.
-
-  3. Slurm compute nodes must be marked with the ```HIL``` feature in
+  2. Slurm compute nodes must be marked with the ```HIL``` feature in
   order to be placed in a HIL reservation.  Features are defined in
   the ```slurm.conf``` file or may be added to a node by a privileged
   user via the ```scontrol update``` command.  Refer to the Slurm
-  documenation for a description of how to do this.
+  documentation for a description of how to do this.
+
+  3. The Slurm controller node in the partition is not available for
+  HIL operations and is **not** marked with the ```HIL``` feature.
 
   4. HIL nodes may be released from a HIL reservation through
   ```hil_release```, even though they are not up and running Linux.
@@ -180,7 +179,7 @@ following apply to the user level Slurm reservation software.
   detailed system behavior has not been fully evaluated and is likely
   to evolve over time.
 
-  5. Python v2.7 must be installed on the Slurm controller node.
+  5. Python 2.7 must be installed on the Slurm controller node.
 
   6. The ```hil_reserve``` and ```hil_release``` commands must be
   available on both the Slurm controller node and on the compute nodes
@@ -209,6 +208,9 @@ may be reviewed as necessary to gain insight into system behavior.
   location of this file is configured in the
   ```hil_slurm_settings.py``` file.  By default, the location is
   ```/var/log/moc_hil_ulsr/hil_monitor.log```. 
+
+  * The HIL server, if configured to run on the Slurm controller node,
+  writes to ```/var/log/hil.log```.
 
 
 # Implementation Details

--- a/commands/hil_slurm_monitor.py
+++ b/commands/hil_slurm_monitor.py
@@ -35,10 +35,9 @@ def _process_reserve_reservations(hil_client, reserve_res_dict_list):
     n = 0
     for reserve_res_dict in reserve_res_dict_list:
         nodelist = hostlist.expand_hostlist(reserve_res_dict['Nodes'])
+        resname = reserve_res_dict['ReservationName']
 
         if hil_reserve_nodes(nodelist, HIL_SLURM_PROJECT, hil_client):
-
-            resname = reserve_res_dict['ReservationName']
             release_resname = resname.replace(HIL_RESERVE, HIL_RELEASE, 1)
             t_start_s = reserve_res_dict['StartTime']
             t_end_s = reserve_res_dict['EndTime']

--- a/commands/hil_slurm_monitor.py
+++ b/commands/hil_slurm_monitor.py
@@ -6,7 +6,6 @@ Slurm / HIL Reservation Monitor
 May 2017, Tim Donahue	tpd001@gmail.com
 """
 
-import fileinput
 import hostlist
 import inspect
 import logging
@@ -18,7 +17,7 @@ from time import time, mktime, strptime
 libdir = realpath(join(dirname(inspect.getfile(inspect.currentframe())), '../common'))
 sys.path.append(libdir)
 
-from hil_slurm_client import hil_init, hil_free_nodes
+from hil_slurm_client import hil_init, hil_reserve_nodes, hil_free_nodes
 from hil_slurm_settings import HIL_MONITOR_LOGFILE, HIL_ENDPOINT, HIL_SLURM_PROJECT
 from hil_slurm_constants import SHOW_OBJ_TIME_FMT, HIL_RESERVE, HIL_RELEASE
 from hil_slurm_helpers import (exec_scontrol_show_cmd, is_hil_reservation, 
@@ -27,31 +26,100 @@ from hil_slurm_helpers import (exec_scontrol_show_cmd, is_hil_reservation,
 from hil_slurm_logging import log_init, log_info, log_debug, log_error
 
 
-def _find_hil_release_reservations(resdata_dict_list):
+def _process_reserve_reservations(hil_client, reserve_res_dict_list):
     '''
-    Traverse the passed list of HIL reservation data
-    Find release reservations which do not have reserve reservations
-    Returns a list of release reservations which should be deleted
+    Move nodes reserved in HIL reserve reservation from the HIL Slurm (loaner) project
+    to the HIL free pool.
+    If successful, create the associated Slurm HIL reserve reservation
     '''
-    all_reservations = {}
-    delete_reservation_dict_list = []
+    n = 0
+    for reserve_res_dict in reserve_res_dict_list:
+        nodelist = hostlist.expand_hostlist(reserve_res_dict['Nodes'])
 
-    for resdata_dict in resdata_dict_list:
-        resname = resdata_dict['ReservationName']
-        all_reservations[resname] = resdata_dict
+        if hil_reserve_nodes(nodelist, HIL_SLURM_PROJECT, hil_client):
 
-    # Look for reserve reservations with matching release reservations
-    # If any singleton release reservations found, add them to the list
-    for resname, resdata_dict in all_reservations.iteritems():
+            resname = reserve_res_dict['ReservationName'].
+            release_resname = resname.replace(HIL_RESERVE, HIL_RELEASE, 1)
+            t_start_s = reserve_res_dict['StartTime']
+            t_end_s = reserve_res_dict['EndTime']
+
+            # $$$ May want to check for pre-existing reservation with same name
+            stdout_data, stderr_data = create_slurm_reservation(release_resname,
+                                                                reserve_res_dict['Users'],
+                                                                t_start_s, t_end_s,
+                                                                nodes=reserve_res_dict['Nodes'],
+                                                                flags=RES_CREATE_FLAGS,
+                                                                features=RES_CREATE_HIL_FEATURES,
+                                                                debug=False)
+            log_hil_reservation(release_resname, stderr_data, t_start_s, t_end_s)
+            n += 1
+        else:
+            log_error('Failed to HIL reserve nodes in reservation `%s`' % resname)
+
+    return n
+
+
+def _process_release_reservations(hil_client, release_res_dict_list):
+    '''
+    Move nodes reserved in HIL release reservations back to the HIL Slurm (loaner) project,
+    then deleted the associated Slurm HIL release reservation
+    '''
+    n = 0
+
+    for release_res_dict in release_res_dict_list:
+        nodelist = hostlist.expand_hostlist(release_res_dict['Nodes'])
+
+        # Attempt to move the node back to the Slurm loaner project
+        # If successful, delete the Slurm (HIL release) reservation
+
+        if hil_free_nodes(nodelist, HIL_SLURM_PROJECT, hil_client):
+
+            release_resname = release_res_dict['ReservationName']
+
+            stdout_data, stderr_data = delete_slurm_reservation(release_resname, debug=False)
+            if (len(stderr_data) == 0):
+               log_info('Deleted HIL release reservation `%s`' % release_resname)
+               n += 1
+            else:
+                log_error('Error deleting HIL release reservation `%s`' % release_resname)
+                log_error(stderr_data)
+    return n
+
+
+def _find_hil_singleton_reservations(hil_reservations_dict, singleton_type):
+    '''
+    Find all reserve or release reservations which do not have a pair
+    release or reserve reservation.  These singleton reservations exist
+    during the HIL reservation creation and release processes, respectively.
+    '''
+    singleton_reservation_dict_list = []
+
+    # Select the pair type based on the reservation type of interest
+
+    if (singleton_type == HIL_RESERVE):
+        pair_type = HIL_RELEASE
+    elif (singleton_type == HIL_RELEASE):
+        pair_type = HIL_RESERVE
+    else:
+        log_error('Invalid reservation type (`%s`)' % pair_type)
+        return singleton_reservation_dict_list
+
+    # Look for reservations which have a pair member.
+    # If any singleton reservations found, add them to the list
+
+    for resname, resdata_dict in hil_reservations_dict.iteritems():
         _, restype, _, _, _ = parse_hil_reservation_name(resname)
-        if restype == HIL_RELEASE:
-            # Check for matching reserve reservation
-            if resname.replace(HIL_RELEASE, HIL_RESERVE, 1) not in all_reservations:
-                delete_reservation_dict_list.append(resdata_dict)
+        if (restype == singleton_type):
+            # Check for matching reservation.  
+            # If found, continue. Else add the singleton to the list.
+            if resname.replace(singleton_type, pair_type, 1) in all_reservations:
+                continue
+            else:
+                singleton_reservation_dict_list.append(resdata_dict)
 
-    return delete_reservation_dict_list
+    return singleton_reservation_dict_list
 
-    
+
 def main(argv=[]):
     '''
     '''
@@ -59,39 +127,50 @@ def main(argv=[]):
 
     # Look for HIL ULSR reservations.
     # If none found, return
-    all_res_dict_list = get_hil_reservations()
-    if not len(all_res_dict_list):
+    hil_reservation_dict_list = get_hil_reservations()
+    if not len(hil_reservation_dict_list):
         return
 
     log_info('HIL Reservation Monitor', separator=True)
     log_debug('')
 
-    # Find HIL ULSR release reservations among all reservations.  
-    # If none found, return
-    release_res_dict_list = _find_hil_release_reservations(all_res_dict_list)
-    if not len(release_res_dict_list):
+    # Construct a dictionary of HIL reservation data, keyed by reservation name.
+    # Values are reservation data dictionaries
+
+    all_hil_reservations_dict = {}
+
+    for resdata_dict in hil_reservation_dict_list:
+        resname = resdata_dict['ReservationName']
+        all_hil_reservations_dict[resname] = resdata_dict
+
+    if not len(all_hil_reservations_dict):
         return
 
-    # Process release reservations.
-    # Establish communications with HIL server
+    # Find singleton RESERVE and RELEASE reservations
+    # If none found, there's nothing to do
+
+    reserve_res_dict_list = _find_hil_singleton_reservations(all_hil_reservations_dict, HIL_RESERVE)
+    release_res_dict_list = _find_hil_singleton_reservations(all_hil_reservations_dict, HIL_RELEASE)
+    if not len(reserve_res_dict_list) and not len(reserve_res_dict_list):
+        return
+
+    # Attempt to connect to the HIL server.
+    # On failure, exit, leaving singleton reservations in place
+
     hil_client = hil_init()
     if not hil_client:
-        log_error('Unable to connect to HIL server `%s` to return nodes' % HIL_ENDPOINT)
-        return False
+        log_error('Unable to connect to HIL server `%s` to process HIL reservations' % HIL_ENDPOINT)
+        return
 
-    # Move loaned nodes from HIL free pool back to Slurm project
-    # If successful, delete the release reservation
-    for release_res_dict in release_res_dict_list:
-        nodelist = hostlist.expand_hostlist(release_res_dict['Nodes'])
+    n_released = _process_release_reservations(hil_client, release_res_dict_list)
+    n_reserved = _process_reserve_reservations(hil_client, reserve_res_dict_list)
 
-        if hil_free_nodes(nodelist, HIL_SLURM_PROJECT, hil_client):
-            resname = release_res_dict['ReservationName']
-            status = delete_slurm_reservation(resname, debug=False)
-            if status:
-               log_info('Deleted reservation `%s`' % resname)
-            else:
-                log_error('Failed to delete reservation `%s`' % resname)
-         
+    if n_released:
+        log_info('HIL monitor: Processed %s release reservations' % n_released)
+    if n_reserved:
+        log_info('HIL monitor: Processed %s reserve reservations' % n_reserved)
+    return
+
 
 if __name__ == '__main__':
     main(sys.argv[1:])

--- a/commands/hil_slurm_monitor.py
+++ b/commands/hil_slurm_monitor.py
@@ -22,7 +22,7 @@ from hil_slurm_settings import HIL_MONITOR_LOGFILE, HIL_ENDPOINT, HIL_SLURM_PROJ
 from hil_slurm_constants import SHOW_OBJ_TIME_FMT, HIL_RESERVE, HIL_RELEASE
 from hil_slurm_helpers import (exec_scontrol_show_cmd, is_hil_reservation, 
                                parse_hil_reservation_name, delete_slurm_reservation,
-                               get_hil_reservations)
+                               get_hil_reservations, log_hil_reservation)
 from hil_slurm_logging import log_init, log_info, log_debug, log_error
 
 
@@ -38,7 +38,7 @@ def _process_reserve_reservations(hil_client, reserve_res_dict_list):
 
         if hil_reserve_nodes(nodelist, HIL_SLURM_PROJECT, hil_client):
 
-            resname = reserve_res_dict['ReservationName'].
+            resname = reserve_res_dict['ReservationName']
             release_resname = resname.replace(HIL_RESERVE, HIL_RELEASE, 1)
             t_start_s = reserve_res_dict['StartTime']
             t_end_s = reserve_res_dict['EndTime']
@@ -112,7 +112,7 @@ def _find_hil_singleton_reservations(hil_reservations_dict, singleton_type):
         if (restype == singleton_type):
             # Check for matching reservation.  
             # If found, continue. Else add the singleton to the list.
-            if resname.replace(singleton_type, pair_type, 1) in all_reservations:
+            if resname.replace(singleton_type, pair_type, 1) hil_reservations_dict:
                 continue
             else:
                 singleton_reservation_dict_list.append(resdata_dict)

--- a/common/hil_slurm_helpers.py
+++ b/common/hil_slurm_helpers.py
@@ -301,7 +301,7 @@ def get_hil_reservations():
     return resdata_dict_list
 
 
-def _log_hil_reservation(resname, stderr_data, t_start_s=None, t_end_s=None):
+def log_hil_reservation(resname, stderr_data, t_start_s=None, t_end_s=None):
     if len(stderr_data):
         log_error('Error creating reservation `%s`'% resname)
         log_error(stderr_data)

--- a/common/hil_slurm_helpers.py
+++ b/common/hil_slurm_helpers.py
@@ -300,4 +300,12 @@ def get_hil_reservations():
 
     return resdata_dict_list
 
+
+def _log_hil_reservation(resname, stderr_data, t_start_s=None, t_end_s=None):
+    if len(stderr_data):
+        log_error('Error creating reservation `%s`'% resname)
+        log_error(stderr_data)
+    else:
+        log_info('Created  HIL reservation `%s`' % resname)
+
 # EOF

--- a/common/hil_slurm_logging.py
+++ b/common/hil_slurm_logging.py
@@ -37,11 +37,11 @@ def _log_common(logger_fn, message=None, separator_s=None, print_exception=False
 
 
 def log_error(message=None):
-    _log_common(logging.error, message, separator_s=warn_error_sep, exception=True)
+    _log_common(logging.error, message, separator_s=warn_error_sep, print_exception=True)
 
 
 def log_warning(message=None):
-    _log_common(logging.warning, message, separator_s=warn_error_sep, exception=True)
+    _log_common(logging.warning, message, separator_s=warn_error_sep, print_exception=True)
 
 
 def log_info(message, separator=False):
@@ -49,7 +49,7 @@ def log_info(message, separator=False):
         s = info_debug_sep
     else:
         s = None
-    _log_common(logging.info, message, separator_s=s, exception=False)
+    _log_common(logging.info, message, separator_s=s, print_exception=False)
 
 
 def log_debug(message, separator=False):
@@ -57,6 +57,6 @@ def log_debug(message, separator=False):
         s = info_debug_sep
     else:
         s = None
-    _log_common(logging.debug, message, separator_s=s, exception=False)
+    _log_common(logging.debug, message, separator_s=s, print_exception=False)
 
 # EOF

--- a/prolog/hil_slurmctld_prolog.py
+++ b/prolog/hil_slurmctld_prolog.py
@@ -248,7 +248,7 @@ def _hil_reserve_cmd(env_dict, pdata_dict, jobdata_dict):
     
     resname, stderr_data = _create_hil_reservation(HIL_RESERVE, t_start_s, t_end_s,
                                                    env_dict, pdata_dict, jobdata_dict)
-    _log_hil_reservation(resname, stderr_data, t_start_s, t_end_s)
+    log_hil_reservation(resname, stderr_data, t_start_s, t_end_s)
 
 
 def _hil_release_cmd(env_dict, pdata_dict, jobdata_dict):


### PR DESCRIPTION
Move HIL client interface functions into the periodic ULSR monitor and out of the Slurm control daemon prolog and epilog.

Create Makefile to handle ULSR software installation on Slurm controller node.  Not yet tested.

Update documentation to reflect change in functional partitioning.  Not yet complete.

Further development needed to adapt to new exception-based error handling model in hil_slurm_client.py.
