### PR TITLE
Use maintenance mode

### DIFF
--- a/common/ulsr_hil_client.py
+++ b/common/ulsr_hil_client.py
@@ -13,11 +13,13 @@ import time
 from hil.client.client import Client, RequestsHTTPClient
 from hil.client.base import FailedAPICallException
 from ulsr_logging import log_info, log_debug, log_error
-from ulsr_settings import HIL_ENDPOINT, HIL_USER, HIL_PW
+from ulsr_settings import HIL_ENDPOINT, HIL_USER, HIL_PW, OBM_NIC, \
+ OBM_NETWORK, MAINTENANCE_PROJECT
 from ulsr_helpers import is_hil_available
 
 # timeout ensures that networking actions are completed in a resonable time.
 HIL_TIMEOUT = 20
+
 
 class HILClientFailure(Exception):
     """Exception indicating that the HIL client failed"""
@@ -70,6 +72,8 @@ def hil_reserve_nodes(nodelist, from_project, hil_client=None):
     We power off the nodes before removing the networks because the IPMI
     network is also controlled by HIL. If we removed all networks, then we will
     not be able to perform any IPMI operations on nodes.
+
+    If this method is called, the nodes moved to the free pool will be powered off.
     '''
     if not is_hil_available():
         return
@@ -80,69 +84,61 @@ def hil_reserve_nodes(nodelist, from_project, hil_client=None):
     # Get information from node and ensure that the node is actually connected
     # to <from_project> before proceeding.
     # iterate over a copy of nodelist, otherwise we can't modify it.
+
     for node in nodelist[:]:
+
         node_info = show_node(hil_client, node)
         project = node_info['project']
+
         # if node already in the free pool, skip any processing.
         if project is None:
             log_info('HIL release: Node `%s` already in the free pool, skipping' % node)
             nodelist.remove(node)
-        elif (project != from_project):
+
+        elif project != from_project and project != MAINTENANCE_PROJECT:
             log_error('HIL reservation failure: Node `%s` (in project `%s`) not in `%s` project' % (node, project, from_project))
             raise ProjectMismatchError()
 
     # Power off all nodes.
+    # Check if the obm network is connected, if not, connect it.
     for node in nodelist:
+        if not _is_network_connected(hil_client, node, OBM_NETWORK, 'vlan/native'):
+            hil_client.node.connect_network(node, OBM_NIC, OBM_NETWORK, 'vlan/native')
+        _ensure_network_connected(hil_client, node, OBM_NETWORK, 'vlan/native')
         power_off_node(hil_client, node)
 
     # Remove all networks from nodes.
     for node in nodelist:
-        try:
-            _remove_all_networks(hil_client, node)
-        except:
-            log_error('Failed to remove networks from node %s' % node)            
-            continue
+        _remove_all_networks(hil_client, node)
 
-    # Finally, remove node from project.
+    # Finally, remove node from `from_project` and MAINTENANCE-PROJECT.
     for node in nodelist:
-        try:
-            _ensure_no_networks(hil_client, node)
-        except:
-            log_error('Failed to ensure node %s is disconnected from all networks' % node)
-            continue
 
-        # tries 10 times to detach the project because there might be a pending
-        # networking action setup by revert port in the previous step.
-        counter = 10
-        while counter:
-            try:
-                hil_client.project.detach(from_project, node)
-                log_info('Node `%s` removed from project `%s`' % (node, from_project))
-                break
-            except FailedAPICallException as ex:
-                if ex.message == 'Node has pending network actions':
-                    counter -= 1
-                    time.sleep(0.5)
-                else:
-                    log_error('HIL reservation failure: Unable to detach node `%s` from project `%s`' % (node, from_project))
-                    raise HILClientFailure(ex.message)
-        if counter == 0:
-            log_error('HIL reservation failure: Unable to detach node `%s` from project `%s`' % (node, from_project))
-            raise HILClientFailure()
+        # this call will check multiple times before raising an error.
+        _ensure_no_networks(hil_client, node)
+        remove_node_from_project(hil_client, node, from_project)
+
+        node_info = show_node(hil_client, node)
+        project = node_info['project']
+
+        if project == MAINTENANCE_PROJECT:
+            remove_node_from_project(hil_client, node, MAINTENANCE_PROJECT)
 
 
 def hil_free_nodes(nodelist, to_project, hil_client=None):
     '''
-    Cause HIL nodes to move the HIL free pool to the 'to' project.
-    Typically, the 'to' project is the Slurm loaner project.
+    Cause HIL nodes to move from the HIL free pool and maintenance-project
+    to the 'to' project. Typically, the 'to' project is the Slurm loaner project.
 
-    This method first powers off the nodes, then disconnects all networks,
-    then moves the node from the free pool to the 'to' project.
+    We connect the obm_network while the nodes are in maintenance-project to
+    poweroff the nodes, and then put them in the `to_project`.
 
-    We power off the nodes before removing the networks because the IPMI
-    network is also controlled by HIL. If we removed all networks, then we will
-    not be able to perform any IPMI operations on nodes.
+    With maintenance-project enabled in HIL, when a non-admin user releases their
+    node, it will always go to the maintenance-project rather than the free pool directyl.
+    hil_reserve_nodes will poweroff any nodes that are in the maintenance-project before
+    putting them in the free pool.
     '''
+
     if not is_hil_available():
         return
 
@@ -157,20 +153,35 @@ def hil_free_nodes(nodelist, to_project, hil_client=None):
 
         # If the node is in the Slurm project now, skip further processing, but don't indicate
         # failure.
+
         project = node_info['project']
+
         if (project == to_project):
             log_info('HIL release: Node `%s` already in `%s` project, skipping' % (node, to_project))
             nodelist.remove(node)
+        elif (project is not None):
+            log_info('Node %s is not in the free pool! skipping.' % node)
+            nodelist.remove(node)
+        else:
+            # put the nodes in the maintenance project
+            connect_node_to_project(hil_client, node, MAINTENANCE_PROJECT)
+
+    for node in nodelist:
+        # now that nodes are in maintenance project. connect the obm_network and
+        # poweroff the nodes.
+        hil_client.node.connect_network(node, OBM_NIC, OBM_NETWORK, 'vlan/native')
+        _ensure_network_connected(hil_client, node, OBM_NETWORK, 'vlan/native')
+        power_off_node(hil_client, node)
+        hil_client.node.detach_network(node, OBM_NIC, OBM_NETWORK)
+        _ensure_no_networks(hil_client, node)
+        hil_client.project.detach(MAINTENANCE_PROJECT, node)
 
     # Finally, connect node to <to_project>
     for node in nodelist:
-        try:
-            hil_client.project.connect(to_project, node)
-            log_info('Node `%s` connected to project `%s`' % (node, to_project))
-        except FailedAPICallException, ConnectionError:
-            log_error('HIL reservation failure: Unable to connect node `%s` to project `%s`' % (node, to_project))
-            raise HILClientFailure()
+        connect_node_to_project(hil_client, node, to_project)
 
+
+# BUNCH OF HELPER METHODS
 
 def _remove_all_networks(hil_client, node):
     '''
@@ -187,48 +198,93 @@ def _remove_all_networks(hil_client, node):
             try:
                 hil_client.port.port_revert(switch, port)
                 log_info('Removed all networks from node `%s`' % node)
-            except FailedAPICallException, ConnectionError:
+            except (FailedAPICallException, ConnectionError) as e:
                 log_error('Failed to revert port `%s` on node `%s` switch `%s`' % (port, node, switch))
-                raise HILClientFailure()
+                raise HILClientFailure(e)
 
 
 def _ensure_no_networks(hil_client, node):
     """Polls on the output of show node to check if networks have been removed.
     It will timeout and raise an exception if it's taking too long.
+
+    This method will be updated to use the show_networking_action API once
+    hil v0.3 is released
     """
-    connected_to_network = True
     end_time = time.time() + HIL_TIMEOUT
-    while connected_to_network:
-        if time.time() > end_time:
-            raise HILClientFailure('Networks not removed from node in reasonable time')
+    while time.time() < end_time:
         node_info = show_node(hil_client, node)
         for nic in node_info['nics']:
             if nic['networks']:
-                connected_to_network = True
                 break
-            else:
-                connected_to_network = False
         # don't tight loop.
         time.sleep(0.5)
-    return
+    raise HILClientFailure('Networks not removed from node %s in reasonable time', node)
+
+
+def _ensure_network_connected(hil_client, node, network, channel):
+    """Polls on the output of show node to check if the specified network
+    was connected or not.
+
+    This method will be updated to use the show_networking_action API once
+    hil v0.3 is released
+    """
+    end_time = time.time() + HIL_TIMEOUT
+    while time.time() < end_time:
+        if _is_network_connected(hil_client, node, network, channel):
+            return
+        # don't tight loop.
+        time.sleep(0.5)
+    raise HILClientFailure('%s is not connected', network)
+
+
+def _is_network_connected(hil_client, node, network, channel):
+    """Returns a boolean indicating whether <network> is connected to <node>
+    or not"""
+    node_info = show_node(hil_client, node)
+    for nic in node_info['nics']:
+        try:
+            if nic['networks'][channel] == network:
+                return True
+        except KeyError:
+            pass
+    return False
 
 
 def show_node(hil_client, node):
     """Returns node information and takes care of handling exceptions"""
+    import pdb; pdb.set_trace()
     try:
         node_info = hil_client.node.show(node)
         return node_info
-    except FailedAPICallException, ConnectionError:
+    except (FailedAPICallException, ConnectionError) as e:
         # log a note for the admins, and the exact exception before raising
         # an error.
-        log_error('HIL reservation failure: HIL node info unavailable, node `%s`' % node)
-        raise HILClientFailure()
+        log_error('show_node for %s failed', node)
+        raise HILClientFailure(e)
 
 
 def power_off_node(hil_client, node):
     try:
         hil_client.node.power_off(node)
         log_info('Node `%s` succesfully powered off' % node)
-    except FailedAPICallException, ConnectionError:
-        log_error('HIL reservation failure: Unable to power off node `%s`' % node)
-        raise HILClientFailure()
+    except (FailedAPICallException, ConnectionError) as e:
+        log_error('Unable to power off node `%s`' % node)
+        raise HILClientFailure(e)
+
+
+def remove_node_from_project(hil_client, node, project):
+    try:
+        hil_client.project.detach(project, node)
+        log_info('Node `%s` removed from project `%s`' % (node, project))
+    except (FailedAPICallException, ConnectionError) as e:
+        log_error('Unable to detach node `%s` from project `%s`' % (node, project))
+        raise HILClientFailure(e)
+
+
+def connect_node_to_project(hil_client, node, project):
+    try:
+        hil_client.project.connect(project, node)
+        log_info('Node `%s` connected to project `%s`' % (node, project))
+    except (FailedAPICallException, ConnectionError) as e:
+        log_error('Unable to connect node `%s` to project `%s`' % (node, project))
+        raise HILClientFailure(e)

--- a/common/ulsr_hil_client.py
+++ b/common/ulsr_hil_client.py
@@ -252,7 +252,6 @@ def _is_network_connected(hil_client, node, network, channel):
 
 def show_node(hil_client, node):
     """Returns node information and takes care of handling exceptions"""
-    import pdb; pdb.set_trace()
     try:
         node_info = hil_client.node.show(node)
         return node_info

--- a/common/ulsr_hil_client.py
+++ b/common/ulsr_hil_client.py
@@ -211,9 +211,13 @@ def _remove_all_networks(hil_client, node):
             try:
                 hil_client.port.port_revert(switch, port)
                 log_info('Removed all networks from node `%s`' % node)
-            except (FailedAPICallException, ConnectionError) as e:
+            except FailedAPICallException as e:
                 log_error('Failed to revert port `%s` on node `%s` switch `%s`' % (port, node, switch))
                 raise HILClientFailure(e)
+            except ConnectionError as e:
+                log_error("_remove_all_networks: Couldn't connect to HIL server.")
+                raise HILClientFailure(e)
+
 
 
 def _ensure_no_networks(hil_client, node):
@@ -268,10 +272,11 @@ def show_node(hil_client, node):
     try:
         node_info = hil_client.node.show(node)
         return node_info
-    except (FailedAPICallException, ConnectionError) as e:
-        # log a note for the admins, and the exact exception before raising
-        # an error.
+    except FailedAPICallException as e:
         log_error('show_node for %s failed', node)
+        raise HILClientFailure(e)
+    except ConnectionError as e:
+        log_error("Show Node: Couldn't connect to HIL server.")
         raise HILClientFailure(e)
 
 
@@ -279,8 +284,11 @@ def power_off_node(hil_client, node):
     try:
         hil_client.node.power_off(node)
         log_info('Node `%s` succesfully powered off' % node)
-    except (FailedAPICallException, ConnectionError) as e:
+    except FailedAPICallExceptionas e:
         log_error('Unable to power off node `%s`' % node)
+        raise HILClientFailure(e)
+    except ConnectionError as e:
+        log_error("power_off_node: Couldn't connect to HIL server.")
         raise HILClientFailure(e)
 
 
@@ -288,8 +296,11 @@ def remove_node_from_project(hil_client, node, project):
     try:
         hil_client.project.detach(project, node)
         log_info('Node `%s` removed from project `%s`' % (node, project))
-    except (FailedAPICallException, ConnectionError) as e:
+    except FailedAPICallException as e:
         log_error('Unable to detach node `%s` from project `%s`' % (node, project))
+        raise HILClientFailure(e)
+    except ConnectionError as e:
+        log_error("remove_node_from_project: Couldn't connect to HIL server.")
         raise HILClientFailure(e)
 
 
@@ -297,6 +308,9 @@ def connect_node_to_project(hil_client, node, project):
     try:
         hil_client.project.connect(project, node)
         log_info('Node `%s` connected to project `%s`' % (node, project))
-    except (FailedAPICallException, ConnectionError) as e:
+    except FailedAPICallException as e:
         log_error('Unable to connect node `%s` to project `%s`' % (node, project))
+        raise HILClientFailure(e)
+    except ConnectionError as e:
+        log_error("connect_node_to_project: Couldn't connect to HIL server.")
         raise HILClientFailure(e)

--- a/common/ulsr_settings.py.default
+++ b/common/ulsr_settings.py.default
@@ -22,6 +22,9 @@ HIL_ENDPOINT = 'http://10.0.0.16:80'
 HIL_USER = 'admin'
 HIL_PW = 'NavedIsSleepy'
 HIL_SLURM_PROJECT = 'slurm'
+MAINTENANCE_PROJECT = 'maintenance'
+OBM_NIC='eth1'
+OBM_NETWORK='obm_network'
 
 ULSR_PARTITION_PREFIX = 'ULSR_partition'
 
@@ -79,7 +82,7 @@ from ulsr_constants import ULSR_RESNAME_PREFIX
 TEST_USER = 'cc'
 TEST_UID = '1000'
 
-TEST_RESNAME = ULSR_RESNAME_PREFIX + 'reserve' + '_' 
+TEST_RESNAME = ULSR_RESNAME_PREFIX + 'reserve' + '_'
 TEST_RESNAME += TEST_USER + '_' + TEST_UID + '_' + '1520606201'
 
 TEST_NODELIST = ['ib-test-2',]
@@ -87,11 +90,11 @@ TEST_NODELIST = ['ib-test-2',]
 TEST_RESDATA = [{'Users': TEST_USER, 'Nodes': TEST_NODELIST, 'ReservationName': TEST_RESNAME,
                  'StartTime': '2018-01-01T00:00:00', 'EndTime': '2018-12-31T23:59:59'}]
 
-TEST_JOB_DATA = [{'JobName': 'hil_reserve', 'TimeLimit': 'UNLIMITED', 
+TEST_JOB_DATA = [{'JobName': 'hil_reserve', 'TimeLimit': 'UNLIMITED',
                   'StartTime': '2018-01-01T00:00:00', 'EndTime': '2018-12-31T23:59:59',
                   'Reservation': TEST_RESNAME}]
 
-TEST_PARTITION_DATA = [{'Shared': 'NO', 'ExclusiveUser': 'YES', 'Default': 'NO', 
+TEST_PARTITION_DATA = [{'Shared': 'NO', 'ExclusiveUser': 'YES', 'Default': 'NO',
                         'State': 'UP', 'PartitionName': ULSR_PARTITION_PREFIX}]
 
 # EOF


### PR DESCRIPTION
@tpd001 I have updated the client to make use of the maintenance mode in hil.
@Izhmash a review would be helpful here.

* There's information in the commit message.

* In short, `hil_free_nodes` will put the nodes in maintenance-project, connect the obm_networks and power them off. After that nodes will be added to the slurm loaner project.

* `hil_reserve_nodes` will connect the obm_network if not connected, power the nodes off.  And then put them in the free pool.

* If users manually release the nodes, the nodes will go to maintenance project, and not the free pool. Admins, however, can still put the nodes in the free pool.

* `hil_free_nodes` and `hil_reserve_nodes` take care of both pools. 

* In Hil v0.3, we have the show_networking_action API which makes it easier to check the status of networking actions. Once we release that (hopefully by the end of this month), I'll update the methods (that poll on something) to use that with an exponential back-off.

* I will push some integration tests tomorrow.

* Important note: This code makes an assumption that all nodes will have a dedicated obm_nic registered in HIL. The label for that nic must be the same for all nodes.

* The diff might show some changes in other lines that because my editor removes trailing spaces.
